### PR TITLE
clock-8x60 : Remove MDP clock freqs not used in original panel driver

### DIFF
--- a/arch/arm/mach-msm/clock-8x60.c
+++ b/arch/arm/mach-msm/clock-8x60.c
@@ -2414,6 +2414,12 @@ static struct rcg_clk jpegd_clk = {
 	}
 static struct clk_freq_tbl clk_tbl_mdp[] = {
 	F_MDP(        0, gnd,  0,  0),
+#ifdef CONFIG_MACH_PYRAMID
+  	F_MDP( 59080000, pll8, 2, 13),
+  	F_MDP(128000000, pll8, 1,  3),
+  	F_MDP(160000000, pll2, 1,  5),
+  	F_MDP(200000000, pll2, 1,  4),
+#else
 	F_MDP(  9600000, pll8, 1, 40),
 	F_MDP( 13710000, pll8, 1, 28),
 	F_MDP( 27000000, pxo,  0,  0),
@@ -2428,6 +2434,7 @@ static struct clk_freq_tbl clk_tbl_mdp[] = {
 	F_MDP(160000000, pll2, 1,  5),
 	F_MDP(177780000, pll2, 2,  9),
 	F_MDP(200000000, pll2, 1,  4),
+#endif
 	F_END
 };
 
@@ -2469,8 +2476,13 @@ static struct rcg_clk mdp_clk = {
 	.c = {
 		.dbg_name = "mdp_clk",
 		.ops = &clk_ops_rcg,
+#ifdef CONFIG_MACH_PYRAMID
+ 		VDD_DIG_FMAX_MAP3(LOW,   59080000, NOMINAL, 200000000,
+ 				  HIGH, 228571000),
+#else
 		VDD_DIG_FMAX_MAP3(LOW,   85330000, NOMINAL, 200000000,
 				  HIGH, 228571000),
+#endif
 		CLK_INIT(mdp_clk.c),
 		.depends = &mdp_axi_clk.c,
 	},


### PR DESCRIPTION
based on https://github.com/sultanxda/sultan-kernel-pyramid-pure-CAF-3.4/commit/489ebc9d7ed789409060c7f9fed66c520b905568

In the original 3.0.16 panel driver, HTC specified a set of MDP clocks to use for scaling: 59MHz, 128MHz, 160MHz, and 200MHz.

This fixes the visual glitch where the very leftmost column of pixels copying what the very rightmost column of pixels displays.

Change-Id: I64f5ee3f530051947a79ca461f9df3ea4eab9f3e
